### PR TITLE
chore: use "manifest" release command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
-          release-type: node
-          prerelease: true
-          bump-minor-pre-major: true
-          pull-request-title-pattern: 'ci: release ${version}'
+          command: manifest
 
       - name: Checkout
         if: ${{ steps.release.outputs.release_created }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,8 @@
+{
+  ".": {
+    "release-type": "node",
+    "prerelease": true,
+    "bump-minor-pre-major": true,
+    "pull-request-title-pattern": "ci: release ${version}"
+  }
+}


### PR DESCRIPTION
Release Please `prerelease` strategy is broken when used as the input to the GitHub Action directly ([quote](https://github.com/google-github-actions/release-please-action/issues/425#issuecomment-1629422698)). Instead, follow the recommended approach and configure the [Manifest release command](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md).