### PR TITLE
fix: use raw assets urls in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Install the extension from [Visual Studio Marketplace](https://marketplace.visua
 
 When writing test scripts with this extension installed, you can browse the list of all available test script options at any point in time. Take advantage of on-the-fly validation to write tests faster and avoid mistakes.
 
-![Test script intellisense](assets/intellisense-suggestions.png)
+![Test script intellisense](https://raw.github.com/artilleryio/vscode-artillery/main/assets/intellisense-suggestions.png)
 
 > Learn more about [Writing test scripts with Artillery](https://www.artillery.io/docs/reference/test-script).
 
 Explore existing test scripts by hovering at any of its properties to get a short description, examples, and links to the documentation to learn more.
 
-![Inline tooltips for existing properties](assets/intellisense-tooltips.png)
+![Inline tooltips for existing properties](https://raw.github.com/artilleryio/vscode-artillery/main/assets/intellisense-tooltips.png)
 
 ### Inline test runs
 


### PR DESCRIPTION
- Links the assets in README to their absolute URLs to raw asset files. 

> Note: Since the repository is private, the URL requires to have a PAT set as the `token` URL search parameter. I'm omitting this for now. Until we make the repo public, the README images will be broken. 