### PR TITLE
fix: set ["*.yml", "*.yaml"] as the default pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,16 @@
       "title": "Artillery",
       "properties": {
         "vscode-artillery.testMatch": {
-          "type": "string",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minItems": 1
+          },
           "description": "Glob of the Artillery test scripts.",
-          "default": "*.yml",
+          "default": [
+            "*.yaml",
+            "*.yml"
+          ],
           "examples": [
             "test.yml",
             "**/*.test.yml"


### PR DESCRIPTION
## Changes

- Sets `['*.yml', '*.yaml']` as the default value for the `testMatch` option (previously, `"*.yml"`).
- The `testMatch` option must now be an array of strings (previously, a single string). This is already supported by [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and it gives more versatility to the user. 
