### PR TITLE
fix: use npx to spawn artillery cli

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,13 +49,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const terminal = vscode.window.createTerminal()
         terminal.show()
 
-        /**
-         * @todo Check if the Artillery CLI is installed.
-         * If not, prompt to install it.
-         * We can also have an "Install Artillery CLI" as a command,
-         * reusing it here.
-         */
-        const runCommand = `artillery run ${testScriptPath}`
+        const runCommand = `npx artillery run ${testScriptPath}`
         terminal.sendText(runCommand, true)
       },
     ),


### PR DESCRIPTION
- Fixes ART-1303

Use `npx artillery` to spawn our CLI when using the "Run load test" code lens option. This way users that don't have Artillery installed will be prompted to install it before running the test. 